### PR TITLE
Extracting Rover component from Square

### DIFF
--- a/packages/components/Rover.js
+++ b/packages/components/Rover.js
@@ -1,0 +1,24 @@
+import { Icon } from "@chakra-ui/react";
+import {
+  FaAngleDoubleUp,
+  FaAngleDoubleDown,
+  FaAngleDoubleLeft,
+  FaAngleDoubleRight,
+} from "react-icons/fa";
+
+export default function Rover(props) {
+  function determineArrowIcon() {
+    let icon = FaAngleDoubleUp
+    if (props.direction === "S") {
+      icon = FaAngleDoubleDown
+    } else if( props.direction === "E") {
+      icon = FaAngleDoubleRight
+    } else if (props.direction === "W" ) {
+      icon = FaAngleDoubleLeft
+    }
+    return icon
+  }
+  return (
+    <Icon as={determineArrowIcon()} fontSize="5xl" color="white" />
+  )
+}

--- a/packages/components/Square.js
+++ b/packages/components/Square.js
@@ -1,27 +1,11 @@
-import { Box, Icon, Center } from "@chakra-ui/react";
-import {
-  FaAngleDoubleUp,
-  FaAngleDoubleDown,
-  FaAngleDoubleLeft,
-  FaAngleDoubleRight,
-} from "react-icons/fa";
+import { Box, Center } from "@chakra-ui/react";
+import Rover from "./Rover";
 
 export default function Square(props) {
-  function determineArrowIcon(direction) {
-    let icon = FaAngleDoubleUp
-    if (direction === "S") {
-      icon = FaAngleDoubleDown
-    } else if( direction === "E") {
-      icon = FaAngleDoubleRight
-    } else if (direction === "W" ) {
-      icon = FaAngleDoubleLeft
-    }
-    return icon
-  }
 
   const notOccupiedTemplate = "";
   const occupiedTemplate = (
-    <Icon as={determineArrowIcon(props.direction)} fontSize="5xl" color="white" />
+    <Rover direction={props.direction} />
   );
   return (
     <Box

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,6 @@ function createSquaresMatrix() {
         coordinates: [x, y],
         id: x + y * 5,
         index: 5 * (4 - y) + x,
-        direction: "N",
         neighborsIndex: {
           N: y + 1 <= 4 ? 5 * (4 - (y + 1)) + x : "",
           S: y - 1 >= 0 ? 5 * (4 - (y - 1)) + x : "",


### PR DESCRIPTION
 - create roverdirection state hook
 - using setRoverState instead of modifying the direction key in
   SqareObject.
 - remove direction key from squareObject.
 - remove setPositionErr from determineFinalSquare, so avoiding that the
   rover position is changed when the command leads to an invalid
   position